### PR TITLE
Add pdal as dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     - run:
         name: Install requirements
         command: | 
-          conda env create -q -f environment.yml
+          conda env create -f environment.yml
           # pip install -r requirements.txt
           # pip install black
     - run:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
-- "conda env create -q -f environment.yml"
+- "conda env create -f environment.yml"
 - activate surfclass
 # - pip install -r requirements.txt
 - pip install ".[dev]"

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,8 @@
 name: surfclass
+channels:
+  - conda-forge
 dependencies:
   - python=3.7
-  - gdal
+  - gdal=3.*
+  - python-pdal=2.*
   - pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click>=6.0
 gdal>=2.3
+pdal>=2.2

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-INSTALL_REQUIRES = ["click", "gdal>=2.3"]
+INSTALL_REQUIRES = ["click", "gdal>=3", "pdal>=2"]
 
 EXTRAS_REQUIRE = {"dev": ["pytest", "black"]}
 ENTRY_POINTS = """


### PR DESCRIPTION
In conda it is possible to install the pdal binaries only. Ie without python bindings. In conda this package is called `pdal`. The conda package with the python bindings is called `python-pdal`.

The pypi package with pdal bindings is called `pdal`.