### PR TITLE
Do not hard code version in cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ src/*.egg-info
 src/surfclass/*.egg-info
 src/surfclass/__pycache__
 tests/__pycache__
+
+# Type checking
+.mypy_cache

--- a/README.md
+++ b/README.md
@@ -16,5 +16,3 @@ conda env create -n surfclass -f environment.yml
 conda activate surfclass
 pip install .
 ```
-
-Nicolai Master test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click>=6.0
+click_plugins
 gdal>=2.3
 pdal>=2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [pylint]
 # Run with: pylint --rcfile=setup.cfg src
 max-line-length=88
-disable = C0103,C0111,W0107
+disable = C0103,C0111,W0703
 #ignore = migrations
 ignore-docstrings = yes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [pylint]
 # Run with: pylint --rcfile=setup.cfg src
 max-line-length=88
-disable = C0103,C0111
+disable = C0103,C0111,W0107
 #ignore = migrations
 ignore-docstrings = yes
 

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,15 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-INSTALL_REQUIRES = ["click", "gdal>=3", "pdal>=2"]
+INSTALL_REQUIRES = ["click", "click_plugins", "gdal>=3", "pdal>=2"]
 
 EXTRAS_REQUIRE = {"dev": ["pytest", "black"]}
 ENTRY_POINTS = """
       [console_scripts]
       surfclass=surfclass.scripts.cli:cli
+
+      [surfclass.surfclass_commands]
+      prepare=surfclass.scripts.prepare:prepare
 """
 
 ###############################################################################

--- a/src/surfclass/scripts/cli.py
+++ b/src/surfclass/scripts/cli.py
@@ -1,5 +1,6 @@
 import sys
 import click
+from surfclass import __version__
 
 
 def print_stderr(*args, **kwargs):
@@ -14,7 +15,7 @@ def print_stderr(*args, **kwargs):
 
 
 @click.group("surfclass")
-@click.version_option(version="0.0.1")
+@click.version_option(version=__version__)
 def cli():
     pass
 

--- a/src/surfclass/scripts/cli.py
+++ b/src/surfclass/scripts/cli.py
@@ -1,28 +1,24 @@
-import sys
+import logging
 import click
 from click_plugins import with_plugins
 from pkg_resources import iter_entry_points
 from surfclass import __version__
+from surfclass.scripts import options
+from surfclass.scripts.helpers import ClickColoredLoggingFormatter, ClickLoggingHandler
+
+logger = logging.getLogger(__name__)
 
 
-def print_stderr(*args, **kwargs):
-    """
-    Prints messages to stderr
-    The function eprint can be used in the same was as the standard print function
-    :param args:
-    :param kwargs:
-    :return:
-    """
-    print(*args, file=sys.stderr, **kwargs)
+def configure_logging(log_level):
+    handler = ClickLoggingHandler()
+    handler.formatter = ClickColoredLoggingFormatter("%(name)s: %(message)s")
+    logging.basicConfig(level=log_level.upper(), handlers=[handler])
 
 
 @with_plugins(iter_entry_points("surfclass.surfclass_commands"))
 @click.group("surfclass")
 @click.version_option(version=__version__)
-def cli():
+@options.verbosity_arg
+def cli(verbosity):
     """surfclass command line interface"""
-    pass
-
-
-if __name__ == "__main__":
-    cli()
+    configure_logging(verbosity)

--- a/src/surfclass/scripts/cli.py
+++ b/src/surfclass/scripts/cli.py
@@ -1,5 +1,7 @@
 import sys
 import click
+from click_plugins import with_plugins
+from pkg_resources import iter_entry_points
 from surfclass import __version__
 
 
@@ -14,9 +16,11 @@ def print_stderr(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
+@with_plugins(iter_entry_points("surfclass.surfclass_commands"))
 @click.group("surfclass")
 @click.version_option(version=__version__)
 def cli():
+    """surfclass command line interface"""
     pass
 
 

--- a/src/surfclass/scripts/helpers.py
+++ b/src/surfclass/scripts/helpers.py
@@ -1,0 +1,38 @@
+import logging
+import click
+
+
+class ClickColoredLoggingFormatter(logging.Formatter):
+    default_colors = {
+        "error": dict(fg="red"),
+        "exception": dict(fg="red"),
+        "critical": dict(fg="red"),
+        "debug": dict(fg="blue"),
+        "warning": dict(fg="yellow"),
+    }
+
+    def __init__(self, fmt=None, datefmt=None, colors=None):
+        super(ClickColoredLoggingFormatter, self).__init__(fmt, datefmt)
+        self.colors = colors or ClickColoredLoggingFormatter.default_colors
+
+    def format(self, record):
+        if not record.exc_info:
+            level = record.levelname.lower()
+            msg = record.getMessage()
+            if level in self.colors:
+                prefix = click.style("{}: ".format(level), **self.colors[level])
+                # msg = "\n".join(prefix + x for x in msg.splitlines())
+                msg = prefix + logging.Formatter.format(self, record)
+            return msg
+        return logging.Formatter.format(self, record)
+
+
+class ClickLoggingHandler(logging.Handler):
+    _use_stderr = True
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            click.echo(msg, err=self._use_stderr)
+        except Exception:
+            self.handleError(record)

--- a/src/surfclass/scripts/options.py
+++ b/src/surfclass/scripts/options.py
@@ -1,0 +1,11 @@
+import click
+
+verbosity_arg = click.option(
+    "--verbosity",
+    "-v",
+    type=click.Choice(
+        ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"], case_sensitive=False
+    ),
+    default="ERROR",
+    help="Set verbosity level",
+)

--- a/src/surfclass/scripts/prepare.py
+++ b/src/surfclass/scripts/prepare.py
@@ -1,0 +1,13 @@
+import click
+
+
+@click.group()
+def prepare():
+    """Prepare data for surfclass"""
+    pass
+
+
+@prepare.command()
+def lidar():
+    """Rasterize lidar data"""
+    pass

--- a/src/surfclass/scripts/prepare.py
+++ b/src/surfclass/scripts/prepare.py
@@ -1,13 +1,15 @@
+import logging
 import click
+
+logger = logging.getLogger(__name__)
 
 
 @click.group()
 def prepare():
     """Prepare data for surfclass"""
-    pass
 
 
 @prepare.command()
 def lidar():
     """Rasterize lidar data"""
-    pass
+    logger.debug("Preparing lidar data")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture(scope="function")
+def cli_runner():
+    return CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,18 +1,13 @@
-from click.testing import CliRunner
 import surfclass
 from surfclass.scripts.cli import cli
 
 
-def test_cli():
-    runner = CliRunner()
-    result = runner.invoke(cli, ["--version"])
-
+def test_cli(cli_runner):
+    result = cli_runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
 
 
-def test_cli_version():
-    runner = CliRunner()
-    result = runner.invoke(cli, ["--version"])
-
+def test_cli_version(cli_runner):
+    result = cli_runner.invoke(cli, ["--version"])
     expected = f"surfclass, version {surfclass.__version__}\n"
     assert result.output == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from click.testing import CliRunner
+import surfclass
 from surfclass.scripts.cli import cli
 
 
@@ -7,3 +8,11 @@ def test_cli():
     result = runner.invoke(cli, ["--version"])
 
     assert result.exit_code == 0
+
+
+def test_cli_version():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+
+    expected = f"surfclass, version {surfclass.__version__}\n"
+    assert result.output == expected

--- a/tests/test_cli_prepare.py
+++ b/tests/test_cli_prepare.py
@@ -1,0 +1,11 @@
+from surfclass.scripts.cli import cli
+
+
+def test_cli_prepare(cli_runner):
+    result = cli_runner.invoke(cli, ["prepare"])
+    assert result.exit_code == 0
+
+
+def test_cli_prepare_lidar(cli_runner):
+    result = cli_runner.invoke(cli, ["prepare", "lidar"])
+    assert result.exit_code == 0


### PR DESCRIPTION
- Do not hard code version number in cli
- Use click plugins
- add "prepare" click command group (and dummy "lidar" command) like: `surfclass prepare lidar --option --option`
- Allow for log output to console. Syntax is a little stange for now as the verbosity option MUST immediately follow `surfclass` like: `surfclass -v debug prepare lidar` 