### PR TITLE
Make bbox argument optional for extractfeatures

### DIFF
--- a/src/surfclass/kernelfeatureextraction.py
+++ b/src/surfclass/kernelfeatureextraction.py
@@ -34,10 +34,10 @@ class KernelFeatureExtraction:
         self,
         raster_path,
         outdir,
-        bbox,
         outputfeatures,
         neighborhood=5,
         crop_mode="reflect",
+        bbox=None,
         prefix=None,
         postfix=None,
     ):
@@ -60,10 +60,10 @@ class KernelFeatureExtraction:
         self.fileprefix = prefix or ""
         # str, "": Optional file postfixfix
         self.filepostfix = postfix or ""
-        # surfclass.Bbox: Bounding Box (xmin,ymin,xmax,ymax)
-        self.bbox = Bbox(*bbox)
         # rasterio.RasterReader: Class for reading rasters
         self.rasterreader = rasterio.RasterReader(raster_path)
+        # surfclass.Bbox: Bounding Box (xmin,ymin,xmax,ymax)
+        self.bbox = Bbox(*bbox) if bbox else self.rasterreader.bbox
         # float: Nodata value for masking
         self.nodata = self.rasterreader.nodata
         # np.array: Non-masked array read using Raster

--- a/src/surfclass/scripts/prepare.py
+++ b/src/surfclass/scripts/prepare.py
@@ -127,7 +127,7 @@ def extractfeatures(
     Example:
     surfclass prepare extractfeatures -b 721000 6150000 722000 6151000
         -n 5 -c reflect -f mean -f var 1km_6150_721_amplitude.tif c:\outdir\
-            
+
     """
     # TODO: Add more edge handling strategies
     # Log inputs

--- a/src/surfclass/scripts/prepare.py
+++ b/src/surfclass/scripts/prepare.py
@@ -78,7 +78,7 @@ def lidargrid(lidarfile, bbox, srs, resolution, dimension, outdir, prefix, postf
 
 
 @prepare.command()
-@options.bbox_opt(required=True)
+@options.bbox_opt(required=False)
 @click.option(
     "-n",
     "--neighborhood",
@@ -127,6 +127,7 @@ def extractfeatures(
     Example:
     surfclass prepare extractfeatures -b 721000 6150000 722000 6151000
         -n 5 -c reflect -f mean -f var 1km_6150_721_amplitude.tif c:\outdir\
+            
     """
     # TODO: Add more edge handling strategies
     # Log inputs
@@ -147,8 +148,8 @@ def extractfeatures(
     featureextractor = KernelFeatureExtraction(
         rasterfile,
         outdir,
-        bbox,
         feature,
+        bbox=bbox,
         neighborhood=neighborhood,
         crop_mode=cropmode,
         prefix=prefix,

--- a/tests/test_kernelfeatureextraction.py
+++ b/tests/test_kernelfeatureextraction.py
@@ -8,7 +8,50 @@ def test_kernelfeatureextraction(amplituderaster_filepath, tmp_path):
     extractor = KernelFeatureExtraction(
         amplituderaster_filepath,
         tmp_path,
-        bbox,
+        ["mean", "var", "diffmean"],
+        bbox=bbox,
+        prefix="test",
+        crop_mode="crop",
+    )
+
+    # Test basic assertion about the input array
+    assert extractor
+    assert extractor.array.shape == (250, 250)
+    assert extractor.array.sum() == -4189377.63
+    assert extractor.nodata == -999.0
+
+    # Calculate derived features with the "crop" method
+    feature_generator = extractor.calculate_derived_features()
+    derived_features, _ = zip(*list(feature_generator))
+
+    assert len(derived_features) == 3
+    # Since we cropped size is smaller then input.
+    assert derived_features[0].shape == (246, 246)
+
+    # Calculate derived features with the "reflect" method
+    extractor.crop_mode = "reflect"
+    # Get a new generator
+    feature_generator = extractor.calculate_derived_features()
+    derived_features, _ = zip(*list(feature_generator))
+    assert len(derived_features) == 3
+    # Since we reflected output shape is equal to input shape
+    assert derived_features[0].shape == (250, 250)
+
+    # Test that mean and variance calculation in "simple cases" are correct
+    # Area is picked such that no "nodata" cells are included
+    assert extractor.array[110:115, 110:115].mean() == derived_features[0][112, 112]
+    assert extractor.array[110:115, 110:115].var() == derived_features[1][112, 112]
+
+    # Test DiffMean is correct
+    diffmean = extractor.array[112, 112] - extractor.array[110:115, 110:115].mean()
+    assert diffmean == derived_features[2][112, 112]
+
+
+def test_kernelfeatureextraction_nobbox(amplituderaster_filepath, tmp_path):
+
+    extractor = KernelFeatureExtraction(
+        amplituderaster_filepath,
+        tmp_path,
         ["mean", "var", "diffmean"],
         prefix="test",
         crop_mode="crop",


### PR DESCRIPTION
Read bbox from rasterreader if not given. Fixes #40 