### PR TITLE
Unpin scikit-learn from vulnerable version

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - click-plugins>=1.0.0
   - gdal=3.*
   - python-pdal=2.*
-  - scikit-learn=0.21.*
+  - scikit-learn
   - scipy
   - scikit-image
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.7
   - gdal=3.*
   - python-pdal=2.*
-  - scikit-learn=0.21.*
+  - scikit-learn
   - scipy
   - scikit-image
   - pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ click>=6.0
 click_plugins
 gdal>=2.3
 pdal>=2.2
-scikit-learn==0.21.*
+scikit-learn
 scipy
 scikit-image

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ INSTALL_REQUIRES = [
     "click_plugins",
     "gdal>=3",
     "pdal>=2",
-    "scikit-learn==0.21.*",
+    "scikit-learn",
     "scipy",
     "scikit-image",
 ]


### PR DESCRIPTION
Adresses Dependabot warnings due to CVE-2020-13092.